### PR TITLE
fix: :bug: arregle la ruta para overview

### DIFF
--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -23,7 +23,7 @@ export const NavHeader = ({ className = "" }: NavHeaderProps) => {
                       : "md:pt-2 lg:pt-[33px]"
                   } mx-4 first:ml-0 last:mr-0 font-spartan font-bold leading-25 tracking-1 lg:pb-[7px]`}
                 >
-                  <Link href={`/planets/${p.name}`}>
+                  <Link href={`/planets/${p.name}/overview`}>
                     <h4 className="text-11 text-white/75 uppercase hover:text-white cursor-pointer">
                       {p.name}
                     </h4>


### PR DESCRIPTION
# Vamoacodearplanetas Pull Request 🪐

## Descripcion ✏️
Fallaba el cambio de ruta al hacer click. en otro planeta en el navHeader.

## Cambios visuales 🎨
Al hacer click en un planeta diferente, en el nav header, debería mostrar la infomarción de ese planeta.

## Como testear? 🐛
Hacer click en otro planeta y verificar que se muestra la información correcta.